### PR TITLE
fix: enable `llm-ls` on all types of files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -54,7 +54,7 @@ export function activate(context: vscode.ExtensionContext) {
 	};
 
 	const clientOptions: LanguageClientOptions = {
-		documentSelector: [{ scheme: "file" }],
+		documentSelector: [{ scheme: "*" }],
 	};
 	client = new LanguageClient(
 		'llm',


### PR DESCRIPTION
closes #77 

Note that this does not enable multi-document context, so when using jupyter notebooks, context from other cells will not be used.