### PR TITLE
feat: bump llm-ls to `0.3.0`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   FETCH_DEPTH: 0 # pull in the tags for the version string
-  LLM_LS_VERSION: 0.2.2
+  LLM_LS_VERSION: 0.3.0
 
 jobs:
   package:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "huggingface-vscode",
-  "version": "0.1.3",
+  "version": "0.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "huggingface-vscode",
-      "version": "0.1.3",
+      "version": "0.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "^5.25.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "huggingface-vscode",
   "displayName": "llm-vscode",
   "description": "LLM powered development for VS Code",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "publisher": "HuggingFace",
   "icon": "small_logo.png",
   "engines": {


### PR DESCRIPTION
llm-ls now supports AST parsing to improve suggestions. Based on the cursor's position the AST, suggestions will be empty (no suggestion), single line or multi line.