### PR TITLE
Add SantaCoder model to templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
             "type": "string",
             "enum": [
               "bigcode/starcoder",
+              "bigcode/santacoder",
               "codellama/CodeLlama-13b-hf",
               "Phind/Phind-CodeLlama-34B-v2",
               "WizardLM/WizardCoder-Python-34B-V1.0",

--- a/src/configTemplates.ts
+++ b/src/configTemplates.ts
@@ -1,4 +1,4 @@
-const templateKeys = ["bigcode/starcoder", "codellama/CodeLlama-13b-hf", "Phind/Phind-CodeLlama-34B-v2", "WizardLM/WizardCoder-Python-34B-V1.0", "Custom"] as const;
+const templateKeys = ["bigcode/starcoder", "bigcode/santacoder", "codellama/CodeLlama-13b-hf", "Phind/Phind-CodeLlama-34B-v2", "WizardLM/WizardCoder-Python-34B-V1.0", "Custom"] as const;
 export type TemplateKey = typeof templateKeys[number];
 
 export interface TokenizerPathConfig {
@@ -40,6 +40,20 @@ const StarCoderConfig: Config = {
     }
 }
 
+const SantaCoderConfig: Config = {
+    modelIdOrEndpoint: "bigcode/santacoder",
+    "fillInTheMiddle.enabled": true,
+    "fillInTheMiddle.prefix": "<fim-prefix>",
+    "fillInTheMiddle.middle": "<fim-middle>",
+    "fillInTheMiddle.suffix": "<fim-suffix>",
+    temperature: 0.2,
+    contextWindow: 2048,
+    tokensToClear: ["<|endoftext|>"],
+    tokenizer: {
+        repository: "bigcode/santacoder",
+    }
+}
+
 const CodeLlama13BConfig: Config = {
     modelIdOrEndpoint: "codellama/CodeLlama-13b-hf",
     "fillInTheMiddle.enabled": true,
@@ -69,6 +83,7 @@ const WizardCoderPython34Bv1Config: Config = {
 
 export const templates: Partial<Record<TemplateKey, Config>> = {
     "bigcode/starcoder": StarCoderConfig,
+    "bigcode/santacoder": SantaCoderConfig,
     "codellama/CodeLlama-13b-hf": CodeLlama13BConfig,
     "Phind/Phind-CodeLlama-34B-v2": PhindCodeLlama34Bv2Config,
     "WizardLM/WizardCoder-Python-34B-V1.0": WizardCoderPython34Bv1Config,


### PR DESCRIPTION
[SantaCoder](https://huggingface.co/bigcode/santacoder) model uses different (but very similar) special tokens, comparing to [StarCoder](https://huggingface.co/bigcode/starcoder) model. The current settings contain template only for StarCoder, so it appears to be logical just to change "bigcode/starcoder" to "bigcode/santacoder" in "Model ID or Endpoint" setting. But actually it is not enough, because SantaCoder tokens [start with "fim-"](https://huggingface.co/bigcode/santacoder/blob/cd86b9757a24d90ce2d1b2e26edc4bcacb1e624d/special_tokens_map.json), while StarCoder uses tokens [starting with "fim_"](https://huggingface.co/bigcode/starcoder/blob/354f883c9e9f777cd3eef6820f6c6f6dd892c102/special_tokens_map.json). It is hard to notice by brief settings overview. If wrong FIM tokens are used, it leads to improper work of SantaCoder: "fim_..." tokens are parsed as text, and the model adds them to the output from time to time.

This issue was discussed in [SantaCoder's model page](https://huggingface.co/bigcode/santacoder/discussions/41#65274bd0d4670b0875259db4). To prevent this issue in the future without changing the SantaCoder's interface, I propose to add a separate template for SantaCoder with proper special tokens.