### PR TITLE
feat: add ```llm.requestDelay``` setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,6 +184,11 @@
               "pattern": "**"
             },
             "description": "Filter documents to enable suggestions for"
+          },
+          "llm.requestDelay": {
+            "type": "float",
+            "default": 1.5,
+            "description": "Minimum time interval between requests. This setting avoids unnecessary API calls, typically when the user is still typing."
           }
         }
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -135,6 +135,8 @@ export function activate(context: vscode.ExtensionContext) {
 			if (position.line <= 0) {
 				return;
 			}
+			// wait for new changes, then send request
+			await delay(config.get("requestDelay") as number);
 
 			let params = {
 				position,
@@ -297,4 +299,8 @@ export default async function highlightStackAttributions(): Promise<void> {
 	setTimeout(() => {
 		vscode.window.activeTextEditor?.setDecorations(decorationType, []);
 	}, 5000);
+}
+
+function delay(s: number) {
+    return new Promise( resolve => setTimeout(resolve, s * 1000) );
 }


### PR DESCRIPTION
This PR introduces the setting ```llm.requestDelay```. It represents the minimum time interval between requests. This setting avoids unnecessary API calls, typically when the user is still typing. For instance, if ```requestDelay``` is set to ```2```, the extension waits 2 seconds for something to be typed, otherwise makes an API call. Prior to this PR, every single character typed would result in a new call, overloading the API with many irrelevant requests, and most of the time making the user wait for all requests to be satisfied even if not needed anymore.
