### PR TITLE
feat: add llm.requestDelay setting v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,11 @@
       {
         "title": "Llm",
         "properties": {
+          "llm.requestDelay": {
+            "type": "integer",
+            "default": 150,
+            "description": "Delay between requests in milliseconds"
+          },
           "llm.enableAutoSuggest": {
             "type": "boolean",
             "default": true,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -329,7 +329,7 @@ async function delay(milliseconds: number, token: vscode.CancellationToken): Pro
 
         setTimeout(() => {
             clearInterval(interval);
-			resolve(!token.isCancellationRequested)
+            resolve(!token.isCancellationRequested)
         }, milliseconds);
     });
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -137,11 +137,8 @@ export function activate(context: vscode.ExtensionContext) {
 				return;
 			}
 			if (requestDelay > 0){
-				// wait for requestDelay milliseconds, unless the token is cancelled
-				// before sending the request.
-				const shouldContinue = await delay(requestDelay, token);
-				if (!shouldContinue){
-					// If delay was cancelled, return early without sending the request.
+				const cancelled = await delay(requestDelay, token);
+				if (cancelled){
 					return
 				}
 			}
@@ -315,7 +312,7 @@ async function delay(milliseconds: number, token: vscode.CancellationToken): Pro
 	 *
 	 * @param milliseconds number of milliseconds to wait
 	 * @param token cancellation token
-	 * @returns a promise that resolves with true after N milliseconds, or false if the token is cancelled.
+	 * @returns a promise that resolves with false after N milliseconds, or true if the token is cancelled.
 	 *
 	 * @remarks This is a workaround for the lack of a debounce function in vscode.
 	*/
@@ -323,13 +320,13 @@ async function delay(milliseconds: number, token: vscode.CancellationToken): Pro
         const interval = setInterval(() => {
             if (token.isCancellationRequested) {
                 clearInterval(interval);
-                resolve(false)
+                resolve(true)
             }
         }, 10); // Check every 10 milliseconds for cancellation
 
         setTimeout(() => {
             clearInterval(interval);
-            resolve(!token.isCancellationRequested)
+            resolve(token.isCancellationRequested)
         }, milliseconds);
     });
 }


### PR DESCRIPTION
Hi @McPatate 👋 

This PR is based on https://github.com/huggingface/llm-vscode/pull/103 by @davidpissarra which looks stale without further improvements / changes for a month, but which brings a really neat feature imo :)

As the original PR, it adds the `llm.requestDelay` setting, representing the minimum time interval between requests, in __milliseconds__ though. It now defaults to `150ms` in addition to taking into account the cancellation token.

Hope this helps! I would not mind declining this PR if any changes happen to be made on the other one.
Thanks for your review