### PR TITLE
fix: allow auto-completion on the first line

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -132,7 +132,7 @@ export function activate(context: vscode.ExtensionContext) {
 			if (context.triggerKind === vscode.InlineCompletionTriggerKind.Automatic && !autoSuggest) {
 				return;
 			}
-			if (position.line <= 0) {
+			if (position.line < 0) {
 				return;
 			}
 


### PR DESCRIPTION
Hi !

While writing https://github.com/huggingface/llm-vscode/pull/111, I came across the following condition:
```typescript
	if (position.line <= 0) {
		return;
	}
```
which __disables the auto-completion on the first line__.

This PR's one and only aim is to allow it for good (it has driven me crazy while demoing this awesome extension :D)
Or is there any reason to disallow this behavior, that I might not be aware of ?

Thanks again for your time & review