### PR TITLE
Add template for DeepSeek coder

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
               "hf/codellama/CodeLlama-13b-hf",
               "hf/Phind/Phind-CodeLlama-34B-v2",
               "hf/WizardLM/WizardCoder-Python-34B-V1.0",
+              "hf/deepseek-ai/deepseek-coder-6.7b-base",
               "ollama/codellama:7b",
               "Custom"
             ],

--- a/src/configTemplates.ts
+++ b/src/configTemplates.ts
@@ -1,4 +1,4 @@
-const templateKeys = ["hf/bigcode/starcoder", "hf/codellama/CodeLlama-13b-hf", "hf/Phind/Phind-CodeLlama-34B-v2", "hf/WizardLM/WizardCoder-Python-34B-V1.0", "ollama/codellama:7b", "Custom"] as const;
+const templateKeys = ["hf/bigcode/starcoder", "hf/codellama/CodeLlama-13b-hf", "hf/Phind/Phind-CodeLlama-34B-v2", "hf/WizardLM/WizardCoder-Python-34B-V1.0", "ollama/codellama:7b", "hf/deepseek-ai/deepseek-coder-6.7b-base", "Custom"] as const;
 export type TemplateKey = typeof templateKeys[number];
 
 export interface TokenizerPathConfig {
@@ -72,6 +72,32 @@ const HfCodeLlama13BConfig: Config = {
 	}
 }
 
+const HfDeepSeekConfig: Config = {
+	modelId: "deepseek-ai/deepseek-coder-6.7b-base",
+	backend: "huggingface",
+	url: null,
+	"fillInTheMiddle.enabled": true,
+	"fillInTheMiddle.prefix": "<｜fim▁begin｜>",
+	// DeepSeek names the suffix token fim_hole, 
+	// as it indicates the position to fill in
+	"fillInTheMiddle.suffix": "<｜fim▁hole｜>",
+	"fillInTheMiddle.middle": "<｜fim▁end｜>",
+	// DeepSeek should support 16k, 
+	// keeping at 8k because of resource constraints
+	contextWindow: 8192,
+	tokensToClear: ["<|EOT|>"],
+	tokenizer: {
+		repository: "deepseek-ai/deepseek-coder-6.7b-base",
+	},
+	requestBody: {
+		parameters: {
+			max_new_tokens: 128,
+			temperature: 0.1,
+			top_p: 0.95
+		}
+	}
+}
+
 const HfPhindCodeLlama34Bv2Config: Config = {
     ...HfCodeLlama13BConfig,
     modelId: "Phind/Phind-CodeLlama-34B-v2",
@@ -108,5 +134,6 @@ export const templates: Partial<Record<TemplateKey, Config>> = {
 	"hf/codellama/CodeLlama-13b-hf": HfCodeLlama13BConfig,
 	"hf/Phind/Phind-CodeLlama-34B-v2": HfPhindCodeLlama34Bv2Config,
 	"hf/WizardLM/WizardCoder-Python-34B-V1.0": HfWizardCoderPython34Bv1Config,
+    "hf/deepseek-ai/deepseek-coder-6.7b-base": HfDeepSeekConfig,
 	"ollama/codellama:7b": OllamaCodeLlama7BConfig,
 }


### PR DESCRIPTION
https://huggingface.co/deepseek-ai/deepseek-coder-6.7b-base
provides some of the best base code LLMs according to the Big Code Leaderboard: https://huggingface.co/spaces/bigcode/bigcode-models-leaderboard

The template for 6.7B should work for the bigger models as well since they use the same tokeniser.