### PR TITLE
Fix temperature config type

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
             "description": "Suffix token"
           },
           "llm.temperature": {
-            "type": "float",
+            "type": "number",
             "default": 0.2,
             "description": "Sampling temperature"
           },


### PR DESCRIPTION
VSCode uses a subset of JSON Schema for configuring extensions: https://code.visualstudio.com/api/references/contribution-points#Configuration-property-schema

JSON Schema doesn't have a `float` type. The `numeric` type can be used to represent floating points and integers: https://json-schema.org/understanding-json-schema/reference/numeric