### PR TITLE
Create context for inline suggestions

### DIFF
--- a/package.json
+++ b/package.json
@@ -226,7 +226,8 @@
     "keybindings": [
       {
         "key": "cmd+shift+l",
-        "command": "editor.action.inlineSuggest.trigger"
+        "command": "editor.action.inlineSuggest.trigger",
+        "when": "!editorFocus || !inSearchEditor"
       },
       {
         "key": "cmd+shift+a",

--- a/package.json
+++ b/package.json
@@ -227,7 +227,7 @@
       {
         "key": "cmd+shift+l",
         "command": "editor.action.inlineSuggest.trigger",
-        "when": "!editorFocus || !inSearchEditor"
+        "when": "!editorFocus && !inSearchEditor"
       },
       {
         "key": "cmd+shift+a",

--- a/package.json
+++ b/package.json
@@ -225,9 +225,8 @@
     ],
     "keybindings": [
       {
-        "key": "cmd+shift+l",
-        "command": "editor.action.inlineSuggest.trigger",
-        "when": "!editorFocus && !inSearchEditor"
+        "key": "cmd+shift+l l",
+        "command": "editor.action.inlineSuggest.trigger"
       },
       {
         "key": "cmd+shift+a",

--- a/package.json
+++ b/package.json
@@ -225,7 +225,7 @@
     ],
     "keybindings": [
       {
-        "key": "cmd+shift+l l",
+        "key": "alt+shift+l",
         "command": "editor.action.inlineSuggest.trigger"
       },
       {


### PR DESCRIPTION
Add context to the keybings as to not overwrite / break existing VSCode keybindings. 

Fixes: https://github.com/huggingface/llm-vscode/issues/138